### PR TITLE
Fix reference download helper

### DIFF
--- a/docker/10xrangers/reference_functions.sh
+++ b/docker/10xrangers/reference_functions.sh
@@ -4,19 +4,33 @@
 # If the file ends in tar.gz, it will be extracted
 download_and_extract() {
     local url="$1"
-    local output_dir=$(pwd)  #"$2"
+    local output_dir=${2:-$(pwd)}
 
     local filename=$(basename "$url")
     local filepath="$output_dir/$filename"
     local extract_dir="$output_dir/${filename%.tar.gz}"
 
-    # Create output directory if it doesn't exist
     mkdir -p "$output_dir"
 
-    # Check if the final file already exists, if so return the path current path
-    if [[ -e "$filepath" ]]; then
-        echo "$filepath"
-        return 0
+    # If the file is a tarball, prefer returning the extracted directory
+    if [[ "$filename" == *.tar.gz ]]; then
+        if [[ -d "$extract_dir" ]]; then
+            echo "$extract_dir"
+            return 0
+        fi
+        if [[ -f "$filepath" ]]; then
+            if ! tar -xzf "$filepath" -C "$output_dir"; then
+                >&2 echo "Error extracting $filepath"
+                return 1
+            fi
+            echo "$extract_dir"
+            return 0
+        fi
+    else
+        if [[ -f "$filepath" ]]; then
+            echo "$filepath"
+            return 0
+        fi
     fi
 
     # Download the file
@@ -24,9 +38,8 @@ download_and_extract() {
         >&2 echo "Error downloading $url"
         return 1
     fi
-    # Check if the file is a tar.gz file
+
     if [[ "$filename" == *.tar.gz ]]; then
-        # Extract the tar.gz file
         if ! tar -xzf "$filepath" -C "$output_dir"; then
             >&2 echo "Error extracting $filepath"
             return 1
@@ -40,7 +53,8 @@ download_and_extract() {
 
 # Download and extract the 10x Genomics reference data, returning the final path
 cellranger_human_reference() {
-    local path=$(download_and_extract $CELLRANGER_HUMAN_REFERENCE_URL)
+    local path
+    path=$(download_and_extract "$CELLRANGER_HUMAN_REFERENCE_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the reference data."
         return 1
@@ -49,7 +63,8 @@ cellranger_human_reference() {
 }
 
 cellranger_mouse_reference() {
-    local path=$(download_and_extract $CELLRANGER_MOUSE_REFERENCE_URL)
+    local path
+    path=$(download_and_extract "$CELLRANGER_MOUSE_REFERENCE_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the reference data."
         return 1
@@ -58,7 +73,8 @@ cellranger_mouse_reference() {
 }
 
 cellranger_human_and_mouse_reference() {
-    local path=$(download_and_extract $CELLRANGER_HUMAN_AND_MOUSE_REFERENCE_URL)
+    local path
+    path=$(download_and_extract "$CELLRANGER_HUMAN_AND_MOUSE_REFERENCE_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the reference data."
         return 1
@@ -67,7 +83,8 @@ cellranger_human_and_mouse_reference() {
 }
 
 cellranger_human_flex_probe_set() {
-    local path=$(download_and_extract $CELLRANGER_HUMAN_FLEX_PROBE_SET_URL)
+    local path
+    path=$(download_and_extract "$CELLRANGER_HUMAN_FLEX_PROBE_SET_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the flex probe set."
         return 1
@@ -76,7 +93,8 @@ cellranger_human_flex_probe_set() {
 }
 
 cellranger_mouse_flex_probe_set() {
-    local path=$(download_and_extract $CELLRANGER_MOUSE_FLEX_PROBE_SET_URL)
+    local path
+    path=$(download_and_extract "$CELLRANGER_MOUSE_FLEX_PROBE_SET_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the flex probe set."
         return 1
@@ -85,7 +103,8 @@ cellranger_mouse_flex_probe_set() {
 }
 
 spaceranger_human_reference() {
-    local path=$(download_and_extract $SPACERANGER_HUMAN_REFERENCE_URL)
+    local path
+    path=$(download_and_extract "$SPACERANGER_HUMAN_REFERENCE_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the reference data."
         return 1
@@ -94,7 +113,8 @@ spaceranger_human_reference() {
 }
 
 spaceranger_mouse_reference() {
-    local path=$(download_and_extract $SPACERANGER_MOUSE_REFERENCE_URL)
+    local path
+    path=$(download_and_extract "$SPACERANGER_MOUSE_REFERENCE_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the reference data."
         return 1
@@ -103,7 +123,8 @@ spaceranger_mouse_reference() {
 }
 
 spaceranger_human_probe_set() {
-    local path=$(download_and_extract $SPACERANGER_HUMAN_PROBE_SET_URL)
+    local path
+    path=$(download_and_extract "$SPACERANGER_HUMAN_PROBE_SET_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the probe set."
         return 1
@@ -112,7 +133,8 @@ spaceranger_human_probe_set() {
 }
 
 spaceranger_mouse_probe_set() {
-    local path=$(download_and_extract $SPACERANGER_MOUSE_PROBE_SET_URL)
+    local path
+    path=$(download_and_extract "$SPACERANGER_MOUSE_PROBE_SET_URL")
     if [ $? -ne 0 ]; then
         >&2 echo "Failed to download or extract the probe set."
         return 1


### PR DESCRIPTION
## Summary
- handle existing extracted paths in the reference download helper script

## Testing
- `shellcheck docker/10xrangers/reference_functions.sh | head -n 5`
- `bash -n docker/10xrangers/reference_functions.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f500c3cb48332960f79401c7cae34